### PR TITLE
Zork theme green tick not showing as green

### DIFF
--- a/themes/zork/zork.theme.bash
+++ b/themes/zork/zork.theme.bash
@@ -2,7 +2,7 @@ SCM_THEME_PROMPT_PREFIX=""
 SCM_THEME_PROMPT_SUFFIX=""
 
 SCM_THEME_PROMPT_DIRTY=" ${bold_red}✗${normal}"
-SCM_THEME_PROMPT_CLEAN=" ${bold_green}✓${normal}"
+SCM_THEME_PROMPT_CLEAN=" ${green}✓${normal}"
 SCM_GIT_CHAR="${bold_green}±${normal}"
 SCM_SVN_CHAR="${bold_cyan}⑆${normal}"
 SCM_HG_CHAR="${bold_red}☿${normal}"


### PR DESCRIPTION
The zork theme SCM_THEME_PROMPT_CLEAN variable of bold_green did not
appear green in some terminal themes (It would appear a grey color). I changed it to just green which seems to look the same or similar.

The two terminal themes I trialed this on were:
 - Pro Mac Terminal Theme
 - Solarized Theme