### PR TITLE
Rename pass function to passgen to avoid conflict with pass (password store) utility.

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -39,7 +39,7 @@ function pickfrom ()
     head -n $n $file | tail -1
 }
 
-function pass ()
+function passgen ()
 {
     about 'generates random password from dictionary words'
     param 'optional integer length'
@@ -52,6 +52,13 @@ function pass ()
     echo "With spaces (easier to memorize): $pass"
     echo "Without (use this as the pass): $(echo $pass | tr -d ' ')"
 }
+
+# Create alias pass to passgen when pass isn't installed or
+# BASH_IT_LEGACY_PASS is true.
+if ! command -v pass &>/dev/null || [ "$BASH_IT_LEGACY_PASS" == 1 ]
+then
+  alias pass=passgen
+fi
 
 function pmdown ()
 {

--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -44,13 +44,13 @@ function passgen ()
     about 'generates random password from dictionary words'
     param 'optional integer length'
     param 'if unset, defaults to 4'
-    example '$ pass'
-    example '$ pass 6'
+    example '$ passgen'
+    example '$ passgen 6'
     group 'base'
-    local i pass length=${1:-4}
+    local i passgen length=${1:-4}
     pass=$(echo $(for i in $(eval echo "{1..$length}"); do pickfrom /usr/share/dict/words; done))
     echo "With spaces (easier to memorize): $pass"
-    echo "Without (use this as the pass): $(echo $pass | tr -d ' ')"
+    echo "Without (use this as the password): $(echo $pass | tr -d ' ')"
 }
 
 # Create alias pass to passgen when pass isn't installed or

--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -55,7 +55,7 @@ function passgen ()
 
 # Create alias pass to passgen when pass isn't installed or
 # BASH_IT_LEGACY_PASS is true.
-if ! command -v pass &>/dev/null || [ "$BASH_IT_LEGACY_PASS" == 1 ]
+if ! command -v pass &>/dev/null || [ "$BASH_IT_LEGACY_PASS" = true ]
 then
   alias pass=passgen
 fi

--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -47,7 +47,7 @@ function passgen ()
     example '$ passgen'
     example '$ passgen 6'
     group 'base'
-    local i passgen length=${1:-4}
+    local i pass length=${1:-4}
     pass=$(echo $(for i in $(eval echo "{1..$length}"); do pickfrom /usr/share/dict/words; done))
     echo "With spaces (easier to memorize): $pass"
     echo "Without (use this as the password): $(echo $pass | tr -d ' ')"


### PR DESCRIPTION
This is in reference to Issue: #399
1. Renamed pass function to passgen.
2. If the pass command (password store) is not found or BASH_IT_LEGACY_PASS is true then define alias pass.
