### PR TITLE
Added BASH_IT_LEGACY_PASS usage notes to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ Set `SCM_GIT_SHOW_DETAILS` to 'false' to **don't show** it:
 
 * `export SCM_GIT_SHOW_DETAILS=false`
 
+#### pass function renamed to passgen
+
+The Bash it `pass` function has been renamed to `passgen` in order to avoid a naming conflict with the [pass password manager]. In order to minimize the impact on users of the legacy Bash it `pass` function, Bash it will create the alias `pass` that calls the new `passgen` function if the `pass` password manager command is not found on the `PATH` (default behavior).
+
+This behavior can be overridden with the `BASH_IT_LEGACY_PASS` flag as follows:
+
+Set `BASH_IT_LEGACY_PASS` to 'true' to force Bash it to always **create** the `pass` alias to `passgen`:
+
+* `export BASH_IT_LEGACY_PASS=true`
+
+Unset `BASH_IT_LEGACY_PASS` to have Bash it **return to default behavior**:
+
+* `unset BASH_IT_LEGACY_PASS`
+
 ## Help out
 
 I think everyone has their own custom scripts accumulated over time.  And so, following in the footsteps of oh-my-zsh, bash it is a framework for easily customizing your bash shell. Everyone's got a custom toolbox, so let's start making them even better, **as a community!**
@@ -95,3 +109,4 @@ Thanks, and happing bashing!
 * [List of contributors][contribute]
 
 [contribute]: https://github.com/revans/bash-it/contributors
+[pass password manager]: http://www.passwordstore.org/


### PR DESCRIPTION
This is in reference to Issue: #399. The addition explains the renaming of the `pass` function to `passgen` and `BASH_IT_LEGACY_PASS` usage.