### PR TITLE
Support brew installed chruby

### DIFF
--- a/plugins/available/chruby-auto.plugin.bash
+++ b/plugins/available/chruby-auto.plugin.bash
@@ -1,5 +1,10 @@
 cite about-plugin
-about-plugin 'load chruby + auto-switching (from /usr/local/share/chruby)'
-
-source /usr/local/share/chruby/chruby.sh
-source /usr/local/share/chruby/auto.sh
+about-plugin 'load chruby + auto-switching'
+if [ -e /usr/opt/local/chruby ]
+then
+  source /usr/local/opt/chruby/share/chruby/chruby.sh
+  source /usr/local/opt/chruby/share/chruby/auto.sh
+else
+  source /usr/local/share/chruby/chruby.sh
+  source /usr/local/share/chruby/auto.sh
+fi

--- a/plugins/available/chruby.plugin.bash
+++ b/plugins/available/chruby.plugin.bash
@@ -1,4 +1,9 @@
 cite about-plugin
 about-plugin 'load chruby                  (from /usr/local/share/chruby)'
 
-source /usr/local/share/chruby/chruby.sh
+if [ -e /usr/opt/local/chruby ]
+then
+  source /usr/local/opt/chruby/share/chruby/chruby.sh
+else
+  source /usr/local/share/chruby/chruby.sh
+fi


### PR DESCRIPTION
Homebrew (on OSX) installs chruby into /usr/opt/local/chruby. These changes allow the chruby and chruby-auto plugins to work with this while retaining support for the usual location for chruby.