### PR TITLE
Fixed reload alias.

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -2,7 +2,14 @@
 # Initialize Bash It
 
 # Reload Library
-alias reload='source ~/.bash_profile'
+case $OSTYPE in
+  darwin*)
+    alias reload='source ~/.bash_profile'
+    ;;
+  *)
+    alias reload='source ~/.bashrc'
+    ;;
+esac
 
 # Only set $BASH_IT if it's not already set
 if [ -z "$BASH_IT" ];


### PR DESCRIPTION
Using the same logic as in the install script. When #396 was added, the `reload` alias was not updated accordingly.