### PR TITLE
Added option for skipping questions in installer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Includes autocompletion, themes, aliases, custom functions, a few stolen pieces 
 The install script will also prompt you asking if you use [Jekyll](https://github.com/mojombo/jekyll).
 This is to set up the `.jekyllconfig` file, which stores info necessary to use the Jekyll plugin.
 
+**INSTALL OPTIONS:**
+The install script can take the following options:
+
+* `--all`: Enable all aliases, plugins and completions.
+* `--none`: Don't enable any aliases, plugins or completions.
+
+If none of these parameters is provided, the install script will ask the user.
 
 ## Help Screens
 

--- a/install.sh
+++ b/install.sh
@@ -18,24 +18,6 @@ cp $HOME/.bash_it/template/bash_profile.template.bash $HOME/$CONFIG_FILE
 
 echo "Copied the template $CONFIG_FILE into ~/$CONFIG_FILE, edit this file to customize bash-it"
 
-while true
-do
-  read -p "Do you use Jekyll? (If you don't know what Jekyll is, answer 'n') [Y/N] " RESP
-
-  case $RESP in
-    [yY])
-      cp $HOME/.bash_it/template/jekyllconfig.template.bash $HOME/.jekyllconfig
-      echo "Copied the template .jekyllconfig into your home directory. Edit this file to customize bash-it for using the Jekyll plugins"
-      break
-      ;;
-    [nN])
-      break
-      ;;
-    *)
-      echo "Please enter Y or N"
-  esac
-done
-
 function load_all() {
   file_type=$1
   [ ! -d "$BASH_IT/$file_type/enabled" ] && mkdir "$BASH_IT/${file_type}/enabled"
@@ -77,28 +59,57 @@ function load_some() {
   done
 }
 
-for type in "aliases" "plugins" "completion"
-do
+if [[ "$1" == "--none" ]]
+then
+  echo "Not enabling any aliases, plugins or completions"
+elif [[ "$1" == "--all" ]]
+then
+  echo "Enabling all aliases, plugins and completions."
+  load_all aliases
+  load_all plugins
+  load_all completion
+else
   while true
   do
-    read -p "Would you like to enable all, some, or no $type? Some of these may make bash slower to start up (especially completion). (all/some/none) " RESP
-    case $RESP
-    in
-    some)
-      load_some $type
-      break
-      ;;
-    all)
-      load_all $type
-      break
-      ;;
-    none)
-      break
-      ;;
-    *)
-      echo "Unknown choice. Please enter some, all, or none"
-      continue
-      ;;
+    read -p "Do you use Jekyll? (If you don't know what Jekyll is, answer 'n') [Y/N] " RESP
+
+    case $RESP in
+      [yY])
+        cp $HOME/.bash_it/template/jekyllconfig.template.bash $HOME/.jekyllconfig
+        echo "Copied the template .jekyllconfig into your home directory. Edit this file to customize bash-it for using the Jekyll plugins"
+        break
+        ;;
+      [nN])
+        break
+        ;;
+      *)
+        echo "Please enter Y or N"
     esac
   done
-done
+
+  for type in "aliases" "plugins" "completion"
+  do
+    while true
+    do
+      read -p "Would you like to enable all, some, or no $type? Some of these may make bash slower to start up (especially completion). (all/some/none) " RESP
+      case $RESP
+      in
+      some)
+        load_some $type
+        break
+        ;;
+      all)
+        load_all $type
+        break
+        ;;
+      none)
+        break
+        ;;
+      *)
+        echo "Unknown choice. Please enter some, all, or none"
+        continue
+        ;;
+      esac
+    done
+  done
+fi


### PR DESCRIPTION
The install script now allows to specify one of the following options:
* `--all`
* `--none`

Both result in any questions being skipped. This is convenient when running the install script from a script, or a provisioning tool like Ansible.